### PR TITLE
fix gateway on windows

### DIFF
--- a/pkg/webircgateway/clientKiwiirc.go
+++ b/pkg/webircgateway/clientKiwiirc.go
@@ -37,7 +37,7 @@ func makeChannel(chanID string, ws sockjs.Session) *Channel {
 	client.RemoteAddr = GetRemoteAddressFromRequest(ws.Request()).String()
 
 	clientHostnames, err := net.LookupAddr(client.RemoteAddr)
-	if err != nil {
+	if err != nil || len(clientHostnames) == 0 {
 		client.RemoteHostname = client.RemoteAddr
 	} else {
 		// FQDNs include a . at the end. Strip it out


### PR DESCRIPTION
windows by default does not have hosts file entries for 127.0.0.1 and ::1 so would return an empty array