### PR TITLE
Possible fix for kiwiirc#56 - Do not send empty caps strings upstream.

### DIFF
--- a/pkg/webircgateway/client_command_handlers.go
+++ b/pkg/webircgateway/client_command_handlers.go
@@ -315,7 +315,13 @@ func (c *Client) ProcessLineFromClient(line string) (string, error) {
 			}
 
 			message.Params[1] = strings.Join(newCaps, " ")
-			line = message.ToLine()
+			if strings.Trim(message.Params[1], " ") == "" {
+				// We fake this because otherwise some servers never respond.
+				c.SendClientSignal("data", "CAP * ACK :message-tags")
+				return "", nil
+			} else {
+				line = message.ToLine()
+			}
 		} else if !containsOneOf(reqCaps, capsThatEnableMessageTags) {
 			// Didn't request anything that needs message-tags cap so disable it
 			c.Features.Messagetags = false


### PR DESCRIPTION
This works around some servers not liking an empty CAP REQ by not forwarding the line if the only thing in it is message tags.