### PR TITLE
fix secure flag for unix domain sockets

### DIFF
--- a/pkg/webircgateway/gateway_utils.go
+++ b/pkg/webircgateway/gateway_utils.go
@@ -8,9 +8,7 @@ import (
 	"strings"
 )
 
-var (
-	v4LoopbackAddr = net.ParseIP("127.0.0.1")
-)
+var v4LoopbackAddr = net.ParseIP("127.0.0.1")
 
 func (s *Gateway) NewClient() *Client {
 	return NewClient(s)
@@ -79,32 +77,12 @@ func (s *Gateway) findWebircPassword(ircHost string) string {
 	return pass
 }
 
-func remoteIPFromRequest(req *http.Request) net.IP {
-	// http.Request.RemoteAddr "has no defined format". With a Unix domain socket on
-	// Linux, it'll probably be "@". Assume anything uninterpretable as host:port is
-	// Unix domain, then treat it as though it were IPv4 loopback:
-	remoteAddr, _, _ := net.SplitHostPort(req.RemoteAddr)
-	if remoteAddr != "" {
-		return net.ParseIP(remoteAddr)
-	} else {
-		return v4LoopbackAddr
-	}
-}
-
 func (s *Gateway) GetRemoteAddressFromRequest(req *http.Request) net.IP {
 	remoteIP := remoteIPFromRequest(req)
 
-	isInRange := false
-	for _, cidrRange := range s.Config.ReverseProxies {
-		if cidrRange.Contains(remoteIP) {
-			isInRange = true
-			break
-		}
-	}
-
 	// If the remoteIP is not in a whitelisted reverse proxy range, don't trust
 	// the headers and use the remoteIP as the users IP
-	if !isInRange {
+	if !s.isTrustedProxy(remoteIP) {
 		return remoteIP
 	}
 
@@ -125,26 +103,31 @@ func (s *Gateway) GetRemoteAddressFromRequest(req *http.Request) net.IP {
 func (s *Gateway) isRequestSecure(req *http.Request) bool {
 	remoteIP := remoteIPFromRequest(req)
 
-	isInRange := false
-	for _, cidrRange := range s.Config.ReverseProxies {
-		if cidrRange.Contains(remoteIP) {
-			isInRange = true
-			break
-		}
-	}
-
 	// If the remoteIP is not in a whitelisted reverse proxy range, don't trust
 	// the headers and check the request directly
-	if !isInRange && req.TLS == nil {
-		return false
-	} else if !isInRange {
-		return true
+	if !s.isTrustedProxy(remoteIP) {
+		return req.TLS != nil
 	}
 
-	headerVal := strings.ToLower(req.Header.Get("x-forwarded-proto"))
-	if headerVal == "https" {
-		return true
-	}
+	fwdProto := req.Header.Get("x-forwarded-proto")
+	return strings.EqualFold(fwdProto, "https")
+}
 
+func (s *Gateway) isTrustedProxy(remoteIP net.IP) bool {
+	for _, cidrRange := range s.Config.ReverseProxies {
+		if cidrRange.Contains(remoteIP) {
+			return true
+		}
+	}
 	return false
+}
+
+func remoteIPFromRequest(req *http.Request) net.IP {
+	if req.RemoteAddr == "@" {
+		// remote address is unix socket, treat it as loopback interface
+		return v4LoopbackAddr
+	}
+
+	remoteAddr, _, _ := net.SplitHostPort(req.RemoteAddr)
+	return net.ParseIP(remoteAddr)
 }


### PR DESCRIPTION
Not sure how you'll feel about this. This treats UNIX domain sockets (and any other `http.Request.RemoteAddr` not interpretable as "ip:port")  as coming from 127.0.0.1, for the purpose of giving connections from whitelisted reverse proxies the secure flag. Since `127.0.0.0/8` is in the default list of reverse proxies, Unix domain sockets will be allowed.

This fixes a problem I was having on darwin.network: I have an nginx in front of the webircgateway, and it connects via Unix domain socket. Those connections were never receiving the `secure` flag, because `isRequestSecure` would always return false when processing a nil IP.