### PR TITLE
Expose recaptcha url via config

### DIFF
--- a/config.conf.example
+++ b/config.conf.example
@@ -16,6 +16,7 @@ send_quit_on_client_close = "Client closed"
 
 [verify]
 recaptcha_url = "https://www.google.com/recaptcha/api/siteverify"
+#recaptcha_url = "https://hcaptcha.com/siteverify"
 recaptcha_secret = ""
 recaptcha_key = ""
 

--- a/config.conf.example
+++ b/config.conf.example
@@ -15,6 +15,7 @@ secret = ""
 send_quit_on_client_close = "Client closed"
 
 [verify]
+recaptcha_url = "https://www.google.com/recaptcha/api/siteverify"
 recaptcha_secret = ""
 recaptcha_key = ""
 

--- a/pkg/recaptcha/recaptcha.go
+++ b/pkg/recaptcha/recaptcha.go
@@ -13,6 +13,7 @@ import (
 // R type represents an object of Recaptcha and has public property Secret,
 // which is secret obtained from google recaptcha tool admin interface
 type R struct {
+	URL       string
 	Secret    string
 	lastError []string
 }
@@ -23,15 +24,12 @@ type googleResponse struct {
 	ErrorCodes []string `json:"error-codes"`
 }
 
-// url to post submitted re-captcha response to
-var postURL = "https://www.google.com/recaptcha/api/siteverify"
-
 // VerifyResponse is a method similar to `Verify`; but doesn't parse the form for you.  Useful if
 // you're receiving the data as a JSON object from a javascript app or similar.
 func (r *R) VerifyResponse(response string) bool {
 	r.lastError = make([]string, 1)
 	client := &http.Client{Timeout: 20 * time.Second}
-	resp, err := client.PostForm(postURL,
+	resp, err := client.PostForm(r.URL,
 		url.Values{"secret": {r.Secret}, "response": {response}})
 	if err != nil {
 		r.lastError = append(r.lastError, err.Error())

--- a/pkg/webircgateway/client_command_handlers.go
+++ b/pkg/webircgateway/client_command_handlers.go
@@ -189,6 +189,7 @@ func (c *Client) ProcessLineFromClient(line string) (string, error) {
 		verified := false
 		if len(message.Params) >= 1 {
 			captcha := recaptcha.R{
+				URL:    c.Gateway.Config.ReCaptchaURL,
 				Secret: c.Gateway.Config.ReCaptchaSecret,
 			}
 

--- a/pkg/webircgateway/config.go
+++ b/pkg/webircgateway/config.go
@@ -73,6 +73,7 @@ type Config struct {
 	Identd                bool
 	RequiresVerification  bool
 	SendQuitOnClientClose string
+	ReCaptchaURL          string
 	ReCaptchaSecret       string
 	ReCaptchaKey          string
 	Secret                string
@@ -142,6 +143,7 @@ func (c *Config) Load() error {
 	c.GatewayWhitelist = []glob.Glob{}
 	c.ReverseProxies = []net.IPNet{}
 	c.Webroot = ""
+	c.ReCaptchaURL = ""
 	c.ReCaptchaSecret = ""
 	c.ReCaptchaKey = ""
 	c.RequiresVerification = false
@@ -180,6 +182,7 @@ func (c *Config) Load() error {
 				c.RequiresVerification = section.Key("required").MustBool(false)
 				c.ReCaptchaSecret = captchaSecret
 			}
+			c.ReCaptchaURL = section.Key("recaptcha_url").MustString("https://www.google.com/recaptcha/api/siteverify")
 		}
 
 		if section.Name() == "dnsbl" {


### PR DESCRIPTION
Expose the recaptcha url via config so hcaptcha can be used as an alternative