### PR TITLE
Change kiwi endpoint path in README to kiwiirc

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@
 * Multiple websocket / transport engine support
     * Websockets (/webirc/websocket/)
     * SockJS (/webirc/sockjs/)
-    * Kiwi IRC multi-servers (/webirc/kiwi/)
+    * Kiwi IRC multi-servers (/webirc/kiwiirc/)
 * Designed for wide web browser support
 * HTTP Origin header whitelisting
 * reCaptcha support


### PR DESCRIPTION
Update it to match the path regestered with the HTTP router in `TransportKiwiirc`'s `Init` method.

(Apologies if I'm missing something. I couldn't get it to work with the path as originally shown.)