### PR TITLE
Enclose readme config option in backticks

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,7 +100,7 @@ Once compiled and you have a config file set, run `./webircgateway --config=conf
 ### Configuration location
 By default the configuration file is looked for in the current directly, ./config.conf. Use the --config parameter to specify a different location.
 
-You may also use a shell command to load your config by prefixing the config option with "$ " like so: --config="$ curl http://example.com/config.conf". Great if you want to remotely include a config file or load it from a service like etcd.
+You may also use a shell command to load your config by prefixing the config option with `$` like so: `--config="$ curl http://example.com/config.conf"`. Great if you want to remotely include a config file or load it from a service like etcd.
 
 Note: All filenames within the configuration file are relative to the configuration file itself unless the filename starts with "/" which makes it an absolute path.
 


### PR DESCRIPTION
In the readme, a line under the "Configuration location" section was being incorrectly formatted. GitHub's markdown renderer was interpreting it as a TeX equation and displaying it with MathJax ([relevant documentation](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/writing-mathematical-expressions)). I've added backticks to correct the behavior.

**Before:**

![1653699959](https://user-images.githubusercontent.com/47096018/170803754-16675f08-1d8d-4c8b-8617-2111f4cc1ba0.png)

**After:**

![1653699974](https://user-images.githubusercontent.com/47096018/170803756-67e6bd32-5c56-4360-a377-8dd247b57be7.png)